### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Android CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/mpwg/template-app-default/security/code-scanning/2](https://github.com/mpwg/template-app-default/security/code-scanning/2)

To fix the problem, explicitly set the workflow or job permissions such that the GITHUB_TOKEN only has the minimum required access. Since all jobs in this workflow use read-only access to repository contents (e.g. checking out code), you should add `permissions: contents: read` either at the workflow (root) level—applies globally to all jobs—or directly within the `android-build-and-test` job. The cleanest approach is to add the block at the top level, below the workflow name and before the `on:` key. No new imports or helper methods are necessary, as this is a YAML configuration only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
