### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: iOS CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/mpwg/template-app-default/security/code-scanning/1](https://github.com/mpwg/template-app-default/security/code-scanning/1)

To remediate this issue, add a `permissions:` block in your workflow YAML to restrict the permissions granted to the default `GITHUB_TOKEN`. Since this workflow only appears to require the ability to read repository contents (for actions such as checking out code and caching dependencies), the minimal safe permission is `contents: read`. For maximum clarity and future safety, place this block at the root level of the workflow file (not inside `jobs:`), so it applies to all jobs unless otherwise overridden. No changes to steps or action versions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
